### PR TITLE
Fix server restart issue

### DIFF
--- a/lib/macaca-adb.js
+++ b/lib/macaca-adb.js
@@ -390,7 +390,7 @@ ADB.prototype.killProcess = function() {
 ADB.prototype.getPIds = function() {
   var args = Array.prototype.slice.call(arguments);
   var name = args[0];
-  var cmd = `ps "${name}"`;
+  var cmd = 'ps';
 
   var promise = new Promise((resolve, reject) => {
     this.shell(cmd).then(data => {


### PR DESCRIPTION
Do not pass package name as the parameter to ps command, it simply returns empty result in certain devices, just call ps command and then filter the pids in _.parseProcess() method